### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS instructions
+
+Este repositório implementa um backend em Python para monitoramento de bebês via FastAPI.
+
+## Execução
+- Inicie o servidor com `python src/main.py`.
+- Execute os testes com `python -m unittest discover tests`.
+
+## Convenções de código
+- Mantenha todos os módulos dentro da pasta `src`.
+- Utilize `snake_case` para variáveis e funções.
+- Escreva docstrings curtas em português ou inglês.
+- Sempre crie testes em `tests/` para novas funcionalidades.
+
+## Commits e Pull Requests
+- Use mensagens de commit curtas em inglês.
+- Rode a suíte de testes antes de abrir um PR.
+
+## Notificações
+- Para enviar push via FCM, use `IdentifiedNotifier` em `src/notifications/identified_notifier.py`.
+- Configure a chave de API do FCM via variável de ambiente `FCM_KEY`.

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from src.camera import CameraHandler
 from src.processing import VideoProcessor
+from src.notifications import TokenRegistry
 
 # Configurações e inicialização de câmera e processador
 driver = {
@@ -19,6 +20,7 @@ driver = {
 }
 camera = CameraHandler(**driver)
 processor = VideoProcessor(camera)
+token_registry = TokenRegistry()
 
 # Eventos para controle de threads de processamento
 t_processing_stop = Event()
@@ -127,6 +129,16 @@ def stream():
         mjpeg_generator(),
         media_type='multipart/x-mixed-replace; boundary=frame'
     )
+
+
+@app.post("/api/register-token")
+def register_token(data: dict):
+    """Recebe token FCM e registra para notificações."""
+    token = data.get("token")
+    if not token:
+        raise HTTPException(400, "Token ausente")
+    token_registry.add(token)
+    return {"status": "ok"}
 
 
 @app.get("/api/latency")

--- a/src/notifications/__init__.py
+++ b/src/notifications/__init__.py
@@ -1,3 +1,5 @@
 from .notifier import Notifier
+from .identified_notifier import IdentifiedNotifier
+from .token_registry import TokenRegistry
 
-__all__ = ["Notifier"]
+__all__ = ["Notifier", "IdentifiedNotifier", "TokenRegistry"]

--- a/src/notifications/identified_notifier.py
+++ b/src/notifications/identified_notifier.py
@@ -1,0 +1,28 @@
+"""FCM notifier with user identification check and spam prevention."""
+
+import time
+from typing import Optional
+
+from .notifier import Notifier
+
+
+class IdentifiedNotifier:
+    """Send FCM notification when a person is identified."""
+
+    def __init__(self, api_key: str, *, threshold: float = 0.9, cooldown: int = 60):
+        self._threshold = threshold
+        self._cooldown = cooldown
+        self._notifier = Notifier(api_key)
+        self._last_sent: float = 0.0
+
+    def notify_if_identified(self, confidence: float, token: str, *, title: str = "Pessoa identificada", message: str = "Uma pessoa conhecida foi detectada") -> None:
+        """Send a notification if confidence exceeds threshold and cooldown expired."""
+        if confidence < self._threshold:
+            return
+
+        now = time.time()
+        if now - self._last_sent < self._cooldown:
+            return
+
+        self._notifier.send(token, title, message)
+        self._last_sent = now

--- a/src/notifications/token_registry.py
+++ b/src/notifications/token_registry.py
@@ -1,0 +1,28 @@
+class TokenRegistry:
+    """Store FCM tokens in a text file."""
+
+    def __init__(self, path: str = "tokens.txt"):
+        self.path = path
+        self.tokens = set()
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            with open(self.path, "r") as fh:
+                self.tokens = set(t.strip() for t in fh if t.strip())
+        except FileNotFoundError:
+            self.tokens = set()
+
+    def _save(self) -> None:
+        with open(self.path, "w") as fh:
+            for t in sorted(self.tokens):
+                fh.write(t + "\n")
+
+    def add(self, token: str) -> None:
+        if not token or token in self.tokens:
+            return
+        self.tokens.add(token)
+        self._save()
+
+    def get_all(self):
+        return list(self.tokens)

--- a/src/processing/video_processor.py
+++ b/src/processing/video_processor.py
@@ -34,3 +34,7 @@ class VideoProcessor:
         results = self.model.predict(source=frame, conf=0.4, classes=[0], verbose=False)
         return results
 
+    def get_processed_frame(self):
+        """Return the latest frame from the camera."""
+        return self.camera.get_frame()
+

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -6,6 +6,8 @@ import importlib
 # Provide fake external modules if not installed
 sys.modules.setdefault('cv2', MagicMock())
 sys.modules.setdefault('onvif', MagicMock())
+sys.modules.setdefault('ultralytics', MagicMock())
+sys.modules.setdefault('pyfcm', MagicMock())
 
 from src.camera.handler import CameraHandler
 from src.processing.video_processor import VideoProcessor
@@ -19,8 +21,10 @@ class TestCameraHandler(unittest.TestCase):
         media_service.GetStreamUri.return_value = MagicMock(Uri='rtsp://cam/stream')
         mock_onvif.return_value.create_media_service.return_value = media_service
 
+        fake_frame = MagicMock()
+        fake_frame.copy.return_value = 'frame'
         fake_cap = MagicMock()
-        fake_cap.read.return_value = (True, 'frame')
+        fake_cap.read.return_value = (True, fake_frame)
         mock_videocap.return_value = fake_cap
 
         cam = CameraHandler('host', 80, 'user', 'pass')

--- a/tests/test_identified_notifier.py
+++ b/tests/test_identified_notifier.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from src.notifications.identified_notifier import IdentifiedNotifier
+
+
+class TestIdentifiedNotifier(unittest.TestCase):
+    @patch('src.notifications.identified_notifier.time')
+    @patch('src.notifications.identified_notifier.Notifier')
+    def test_notify_respects_threshold_and_cooldown(self, mock_notifier_cls, mock_time):
+        mock_notifier = mock_notifier_cls.return_value
+        mock_time.time.side_effect = [100, 130, 200]
+
+        notifier = IdentifiedNotifier('key', threshold=0.5, cooldown=60)
+
+        notifier.notify_if_identified(0.4, 'tkn')
+        self.assertFalse(mock_notifier.send.called)
+
+        notifier.notify_if_identified(0.6, 'tkn')
+        mock_notifier.send.assert_called_once()
+
+        notifier.notify_if_identified(0.7, 'tkn')
+        mock_notifier.send.assert_called_once()
+
+        notifier.notify_if_identified(0.8, 'tkn')
+        self.assertEqual(mock_notifier.send.call_count, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_register_endpoint.py
+++ b/tests/test_register_endpoint.py
@@ -1,0 +1,35 @@
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+import importlib
+
+# provide fake external modules
+sys.modules.setdefault('cv2', MagicMock())
+sys.modules.setdefault('onvif', MagicMock())
+sys.modules.setdefault('ultralytics', MagicMock())
+sys.modules.setdefault('pyfcm', MagicMock())
+
+if importlib.util.find_spec('httpx') is None:
+    raise unittest.SkipTest('httpx not installed')
+
+from fastapi.testclient import TestClient
+
+import src.main as main
+
+
+class TestRegisterEndpoint(unittest.TestCase):
+    def test_register_token(self):
+        with patch.object(main, 'token_registry') as mock_reg, \
+             patch.object(main.camera, 'start'), \
+             patch.object(main.camera, 'stop'), \
+             patch('src.main.Thread') as mock_thread:
+            mock_thread.return_value.start.return_value = None
+            mock_thread.return_value.join.return_value = None
+            client = TestClient(main.app)
+            resp = client.post('/api/register-token', json={'token': 'abc'})
+            self.assertEqual(resp.status_code, 200)
+            mock_reg.add.assert_called_once_with('abc')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_token_registry.py
+++ b/tests/test_token_registry.py
@@ -1,0 +1,25 @@
+import os
+import unittest
+from tempfile import NamedTemporaryFile
+
+from src.notifications.token_registry import TokenRegistry
+
+
+class TestTokenRegistry(unittest.TestCase):
+    def test_add_and_persist(self):
+        with NamedTemporaryFile(delete=False) as tmp:
+            path = tmp.name
+        try:
+            reg = TokenRegistry(path)
+            reg.add("abc")
+            reg.add("abc")
+            reg.add("def")
+
+            reg2 = TokenRegistry(path)
+            self.assertEqual(set(reg2.get_all()), {"abc", "def"})
+        finally:
+            os.remove(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create AGENTS.md with coding and testing guidelines
- add token registry for FCM
- expose a POST endpoint to register tokens
- test token registry persistence and API behaviour

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_68796345fa14832a9c5eada94674b4e4