### PR TITLE
Switch to Firebase Admin SDK for push

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ ultralytics
 onvif-zeep
 sqlalchemy
 psycopg2-binary
-pyfcm
 python-dotenv
 firebase-admin

--- a/src/notifications/notifier.py
+++ b/src/notifications/notifier.py
@@ -1,14 +1,17 @@
-from pyfcm import FCMNotification
+"""Wrapper around Firebase Admin messaging."""
+
+from firebase_admin import messaging
 
 
 class Notifier:
-    """Send push notifications via FCM."""
+    """Send push notifications via Firebase Admin SDK."""
 
-    def __init__(self, api_key: str):
+    def __init__(self, api_key: str | None = None):
         self._api_key = api_key
-        self._client = FCMNotification(api_key=api_key)
 
     def send(self, token: str, title: str, message: str):
-        self._client.notify_single_device(
-            registration_id=token, message_title=title, message_body=message
+        msg = messaging.Message(
+            token=token,
+            notification=messaging.Notification(title=title, body=message),
         )
+        messaging.send(msg)

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -7,7 +7,6 @@ import importlib
 sys.modules.setdefault('cv2', MagicMock())
 sys.modules.setdefault('onvif', MagicMock())
 sys.modules.setdefault('ultralytics', MagicMock())
-sys.modules.setdefault('pyfcm', MagicMock())
 
 from src.camera.handler import CameraHandler
 from src.processing.video_processor import VideoProcessor

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest.mock import patch
+
+from src.notifications.notifier import Notifier
+
+
+class TestNotifier(unittest.TestCase):
+    @patch('src.notifications.notifier.messaging')
+    def test_send_uses_firebase_admin(self, mock_messaging):
+        notifier = Notifier()
+        notifier.send('tok', 'A', 'B')
+        mock_messaging.Notification.assert_called_once_with(title='A', body='B')
+        mock_messaging.Message.assert_called_once_with(
+            token='tok',
+            notification=mock_messaging.Notification.return_value
+        )
+        mock_messaging.send.assert_called_once_with(
+            mock_messaging.Message.return_value
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_register_endpoint.py
+++ b/tests/test_register_endpoint.py
@@ -7,7 +7,6 @@ import importlib
 sys.modules.setdefault('cv2', MagicMock())
 sys.modules.setdefault('onvif', MagicMock())
 sys.modules.setdefault('ultralytics', MagicMock())
-sys.modules.setdefault('pyfcm', MagicMock())
 
 if importlib.util.find_spec('httpx') is None:
     raise unittest.SkipTest('httpx not installed')


### PR DESCRIPTION
## Summary
- swap PyFCM for Firebase Admin SDK in Notifier
- drop the PyFCM dependency
- adjust tests that mocked PyFCM
- add tests for Notifier

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_68797f0f5d90832aa810169e59accb11