### PR TITLE
Refactor Firebase setup into class

### DIFF
--- a/src/firebase_setup.py
+++ b/src/firebase_setup.py
@@ -2,49 +2,45 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+
 import firebase_admin
 from firebase_admin import credentials
 
 
-def _guess_default_path() -> str | None:
-    """serviceAccountKey.json ao lado do repo, se existir."""
-    root = Path(__file__).resolve().parent.parent
-    cand = root / "serviceAccountKey.json"
-    return str(cand) if cand.exists() else None
+class FirebaseSetup:
+    """Inicializa o Firebase Admin SDK."""
 
+    def _guess_default_path(self) -> str | None:
+        """serviceAccountKey.json ao lado do repo, se existir."""
+        root = Path(__file__).resolve().parent.parent
+        cand = root / "serviceAccountKey.json"
+        return str(cand) if cand.exists() else None
 
-def init_firebase(
-    *,
-    app_name: str = "[DEFAULT]",
-    env_var: str = "FIREBASE_CRED",
-    project_id: str | None = None,
-    raise_if_missing: bool = True,
-):
-    """
-    Inicializa (ou devolve) uma instância do Firebase Admin SDK.
+    def init_firebase(
+        self,
+        *,
+        app_name: str = "[DEFAULT]",
+        env_var: str = "FIREBASE_CRED",
+        project_id: str | None = None,
+        raise_if_missing: bool = True,
+    ):
+        """Inicializa (ou devolve) uma instância do Firebase Admin SDK."""
+        try:
+            return firebase_admin.get_app(app_name)
+        except ValueError:
+            pass  # ainda não existe
 
-    - Prioriza o caminho indicado em ``$FIREBASE_CRED``;
-    - Se vazio, tenta ``serviceAccountKey.json`` na raiz do projeto;
-    - Se ambos faltarem, cai em ADC (GOOGLE_APPLICATION_CREDENTIALS) ou
-      lança ``FileNotFoundError`` se ``raise_if_missing`` for True.
-    """
-    try:
-        return firebase_admin.get_app(app_name)
-    except ValueError:
-        pass  # ainda não existe
+        cred_path = os.getenv(env_var) or self._guess_default_path()
 
-    cred_path = os.getenv(env_var) or _guess_default_path()
+        if cred_path:
+            cred = credentials.Certificate(cred_path)
+        else:
+            if raise_if_missing:
+                raise FileNotFoundError(
+                    "Credencial Firebase não encontrada — defina a variável "
+                    f"{env_var} ou coloque serviceAccountKey.json no projeto."
+                )
+            cred = credentials.ApplicationDefault()
 
-    # Se não houver JSON, tente Application Default Credentials
-    if cred_path:
-        cred = credentials.Certificate(cred_path)
-    else:
-        if raise_if_missing:
-            raise FileNotFoundError(
-                "Credencial Firebase não encontrada — defina a variável "
-                f"{env_var} ou coloque serviceAccountKey.json no projeto."
-            )
-        cred = credentials.ApplicationDefault()
-
-    opts = {"projectId": project_id} if project_id else None
-    return firebase_admin.initialize_app(cred, opts, name=app_name)
+        opts = {"projectId": project_id} if project_id else None
+        return firebase_admin.initialize_app(cred, opts, name=app_name)

--- a/src/main.py
+++ b/src/main.py
@@ -9,9 +9,9 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from src.camera import CameraHandler
 from src.processing import VideoProcessor
-from src.notifications import TokenRegistry, IdentifiedNotifier
+from src.notifications import IdentifiedNotifier, TokenRegistry
 from src.monitor.presence_monitor import PresenceMonitor
-from src.firebase_setup import init_firebase
+from src.firebase_setup import FirebaseSetup
 
 # Configurações e inicialização de câmera e processador
 driver = {
@@ -26,7 +26,7 @@ token_registry = TokenRegistry()
 fcm_key = os.getenv("FCM_KEY", "")
 notifier = IdentifiedNotifier(fcm_key, cooldown=60)
 presence_monitor = PresenceMonitor(notifier, token_registry)
-init_firebase()
+FirebaseSetup().init_firebase()
 
 # Eventos para controle de threads de processamento
 t_processing_stop = Event()
@@ -71,9 +71,9 @@ def processing_loop():
         time.sleep(0.01)  # pequena pausa para aliviar CPU
 
 
-
 # FastAPI com contexto de vida (lifespan)
 from contextlib import asynccontextmanager
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -112,13 +112,14 @@ def get_snapshot():
     frame = processor.process_frame()
     if frame is None:
         raise HTTPException(503, "Sem frame disponível")
-    _, jpg = cv2.imencode('.jpg', frame)
+    _, jpg = cv2.imencode(".jpg", frame)
     return Response(jpg.tobytes(), media_type="image/jpeg")
 
 
 @app.get("/api/stream")
 def stream():
     """MJPEG stream com overlay de latência."""
+
     def mjpeg_generator():
         while True:
             frame = camera.get_frame()
@@ -126,17 +127,23 @@ def stream():
                 time.sleep(0.1)
                 continue
             lat = camera.get_last_latency() or 0.0
-            cv2.putText(frame, f"Lat: {lat*1000:.1f} ms", (10, 30),
-                        cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 2)
-            _, jpg = cv2.imencode('.jpg', frame)
+            cv2.putText(
+                frame,
+                f"Lat: {lat*1000:.1f} ms",
+                (10, 30),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.8,
+                (0, 255, 0),
+                2,
+            )
+            _, jpg = cv2.imencode(".jpg", frame)
             yield (
-                b'--frame\r\n'
-                b'Content-Type: image/jpeg\r\n\r\n' + jpg.tobytes() + b'\r\n'
+                b"--frame\r\n"
+                b"Content-Type: image/jpeg\r\n\r\n" + jpg.tobytes() + b"\r\n"
             )
 
     return StreamingResponse(
-        mjpeg_generator(),
-        media_type='multipart/x-mixed-replace; boundary=frame'
+        mjpeg_generator(), media_type="multipart/x-mixed-replace; boundary=frame"
     )
 
 
@@ -156,15 +163,18 @@ def get_latency():
     stats = camera.get_latency_stats()
     if not stats:
         raise HTTPException(503, "Ainda não há medições de latência")
-    return JSONResponse({
-        "last_ms": round(camera.get_last_latency() * 1000, 1),
-        "mean_ms": round(stats["mean"] * 1000, 1),
-        "min_ms": round(stats["min"] * 1000, 1),
-        "max_ms": round(stats["max"] * 1000, 1),
-        "samples": stats["count"]
-    })
+    return JSONResponse(
+        {
+            "last_ms": round(camera.get_last_latency() * 1000, 1),
+            "mean_ms": round(stats["mean"] * 1000, 1),
+            "min_ms": round(stats["min"] * 1000, 1),
+            "max_ms": round(stats["max"] * 1000, 1),
+            "samples": stats["count"],
+        }
+    )
 
 
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run("src.main:app", host="localhost", port=8000, reload=False)

--- a/tests/test_firebase_setup.py
+++ b/tests/test_firebase_setup.py
@@ -1,38 +1,39 @@
 import os
 import sys
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
-sys.modules.setdefault('firebase_admin', MagicMock())
+sys.modules.setdefault("firebase_admin", MagicMock())
 
-from src.firebase_setup import init_firebase
+from src.firebase_setup import FirebaseSetup
 
 
 class TestFirebaseSetup(unittest.TestCase):
-    @patch('src.firebase_setup.firebase_admin')
-    @patch('src.firebase_setup.credentials')
-    @patch('src.firebase_setup.os.path.exists', return_value=True)
-    def test_initialize_called_env(self, mock_exists, mock_credentials, mock_firebase):
+    @patch("src.firebase_setup.firebase_admin")
+    @patch("src.firebase_setup.credentials")
+    def test_initialize_called_env(self, mock_credentials, mock_firebase):
         mock_firebase._apps = []
-        with patch.dict(os.environ, {'FIREBASE_CRED': 'path/key.json'}):
-            init_firebase()
-            mock_credentials.Certificate.assert_called_once_with('path/key.json')
+        mock_firebase.get_app.side_effect = ValueError()
+        with patch.dict(os.environ, {"FIREBASE_CRED": "path/key.json"}):
+            FirebaseSetup().init_firebase()
+            mock_credentials.Certificate.assert_called_once_with("path/key.json")
             mock_firebase.initialize_app.assert_called_once()
 
-    @patch('src.firebase_setup.firebase_admin')
-    @patch('src.firebase_setup.credentials')
-    @patch('src.firebase_setup.os.path')
-    def test_initialize_called_default(self, mock_path, mock_credentials, mock_firebase):
+    @patch("src.firebase_setup.firebase_admin")
+    @patch("src.firebase_setup.credentials")
+    @patch("src.firebase_setup.FirebaseSetup._guess_default_path")
+    def test_initialize_called_default(
+        self, mock_guess, mock_credentials, mock_firebase
+    ):
         mock_firebase._apps = []
-        default_path = os.path.join(os.path.expanduser('~'), 'serviceAccountKey.json')
-        mock_path.exists.return_value = True
-        mock_path.dirname.return_value = os.path.expanduser('~')
-        mock_path.join.return_value = default_path
+        mock_firebase.get_app.side_effect = ValueError()
+        default_path = os.path.join(os.path.expanduser("~"), "serviceAccountKey.json")
+        mock_guess.return_value = default_path
         with patch.dict(os.environ, {}, clear=True):
-            init_firebase()
+            FirebaseSetup().init_firebase()
             mock_credentials.Certificate.assert_called_once_with(default_path)
             mock_firebase.initialize_app.assert_called_once()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- encapsulate Firebase initialization functions into a `FirebaseSetup` class
- use the new class in the main application and tests

## Testing
- `python -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_689657c9d980832ab8354805bebea66a