### PR TITLE
Add dual database modes with memory and MySQL support

### DIFF
--- a/src/db/database.py
+++ b/src/db/database.py
@@ -1,13 +1,19 @@
+"""Database module with variable and MySQL backends."""
+
+import datetime
+from typing import List, Dict, Optional
+
 from sqlalchemy import create_engine, Column, Integer, String, Float, DateTime
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-import datetime
 
 Base = declarative_base()
 
 
 class Event(Base):
-    __tablename__ = 'events'
+    """Tabela de eventos para o banco SQL."""
+
+    __tablename__ = "events"
     id = Column(Integer, primary_key=True)
     type = Column(String)
     confidence = Column(Float)
@@ -15,19 +21,46 @@ class Event(Base):
 
 
 class Database:
-    def __init__(self, url: str):
-        self.engine = create_engine(url)
-        Base.metadata.create_all(self.engine)
-        self.Session = sessionmaker(bind=self.engine)
+    """Banco com suporte a memória ou MySQL."""
+
+    SERVER_MEMORY = 0
+    SERVER_MYSQL = 1
+
+    def __init__(self, server: int = SERVER_MEMORY, url: Optional[str] = None):
+        self.server = server
+        if server == self.SERVER_MEMORY:
+            self._events: List[Dict[str, str]] = []
+        elif server == self.SERVER_MYSQL:
+            if url is None:
+                raise ValueError("URL required for MySQL server")
+            self.engine = create_engine(url)
+            Base.metadata.create_all(self.engine)
+            self.Session = sessionmaker(bind=self.engine)
+        else:
+            raise ValueError("Invalid server option")
 
     def save_event(self, data: dict) -> None:
-        session = self.Session()
-        event = Event(type=data.get('type'), confidence=data.get('confidence'))
-        session.add(event)
-        session.commit()
-        session.close()
+        """Save a new event according to the server type."""
+
+        if self.server == self.SERVER_MEMORY:
+            event = {
+                "type": data.get("type"),
+                "confidence": data.get("confidence"),
+                "timestamp": datetime.datetime.utcnow().isoformat(),
+            }
+            self._events.append(event)
+        else:
+            session = self.Session()
+            event = Event(type=data.get("type"), confidence=data.get("confidence"))
+            session.add(event)
+            session.commit()
+            session.close()
 
     def get_recent_events(self, limit: int = 50):
+        """Return recent events from the chosen backend."""
+
+        if self.server == self.SERVER_MEMORY:
+            return list(reversed(self._events[-limit:]))
         session = self.Session()
         events = (
             session.query(Event)
@@ -38,9 +71,9 @@ class Database:
         session.close()
         return [
             {
-                'type': e.type,
-                'confidence': e.confidence,
-                'timestamp': e.timestamp.isoformat(),
+                "type": e.type,
+                "confidence": e.confidence,
+                "timestamp": e.timestamp.isoformat(),
             }
             for e in events
         ]

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -41,11 +41,20 @@ class TestVideoProcessor(unittest.TestCase):
         self.assertEqual(proc.get_processed_frame(), 'frame')
 
 class TestDatabase(unittest.TestCase):
-    def test_save_and_get_event(self):
+    def test_memory_mode(self):
+        from src.db.database import Database
+        db = Database(server=Database.SERVER_MEMORY)
+        db.save_event({'type': 'mem', 'confidence': 0.5})
+        events = db.get_recent_events()
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]['type'], 'mem')
+        self.assertAlmostEqual(events[0]['confidence'], 0.5)
+
+    def test_sqlalchemy_mode(self):
         if importlib.util.find_spec('sqlalchemy') is None:
             self.skipTest('sqlalchemy not installed')
         from src.db.database import Database
-        db = Database('sqlite:///:memory:')
+        db = Database(server=Database.SERVER_MYSQL, url='sqlite:///:memory:')
         db.save_event({'type': 'test', 'confidence': 0.9})
         events = db.get_recent_events()
         self.assertEqual(len(events), 1)


### PR DESCRIPTION
## Summary
- add Database class supporting memory or MySQL backends
- test both memory and SQL modes

## Testing
- `python -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_68966c52a240832a885d1667d5595fb4