### PR TITLE
Log absence events to database

### DIFF
--- a/src/camera/handler.py
+++ b/src/camera/handler.py
@@ -25,6 +25,7 @@ class CameraHandler:
         width: int = 640,
         height: int = 480,
     ):
+        """Configure camera credentials and defaults."""
         self.host = host
         self.port = port
         self.user = user

--- a/src/db/database.py
+++ b/src/db/database.py
@@ -27,6 +27,7 @@ class Database:
     SERVER_MYSQL = 1
 
     def __init__(self, server: int = SERVER_MEMORY, url: Optional[str] = None):
+        """Initialize the database backend."""
         self.server = server
         if server == self.SERVER_MEMORY:
             self._events: List[Dict[str, str]] = []

--- a/src/events/manager.py
+++ b/src/events/manager.py
@@ -2,6 +2,7 @@ class EventManager:
     """Analyzes detections and manages event persistence."""
 
     def __init__(self, db, rules: dict):
+        """Store database handle and event rules."""
         self.db = db
         self.rules = rules
 
@@ -11,5 +12,6 @@ class EventManager:
         return []
 
     def persist(self, events):
+        """Save each event using the database."""
         for ev in events:
             self.db.save_event(ev)

--- a/src/inference/engine.py
+++ b/src/inference/engine.py
@@ -2,6 +2,7 @@ class InferenceEngine:
     """Stub inference engine."""
 
     def __init__(self, model_path: str, device: str = "cpu"):
+        """Store model path and execution device."""
         self.model_path = model_path
         self.device = device
         # Real implementation would load a ML model

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ from src.camera import CameraHandler
 from src.processing import VideoProcessor
 from src.notifications import IdentifiedNotifier, TokenRegistry
 from src.monitor.presence_monitor import PresenceMonitor
+from src.monitor.position_monitor import PositionMonitor
 from src.firebase_setup import FirebaseSetup
 from src.db import Database
 
@@ -21,6 +22,7 @@ driver = {
     "user": os.getenv("CAM_USER", "admin"),
     "passwd": os.getenv("CAM_PASS", "123456"),
 }
+# Inicialização de serviços
 camera = CameraHandler(**driver)
 processor = VideoProcessor(camera)
 token_registry = TokenRegistry()
@@ -32,7 +34,11 @@ if db_url:
 else:
     database = Database(server=Database.SERVER_MEMORY)
 presence_monitor = PresenceMonitor(notifier, token_registry, database)
+position_monitor = PositionMonitor(notifier, token_registry)
 FirebaseSetup().init_firebase()
+
+# Mostrar poses em janela (alterar para True se desejar)
+SHOW_POSE_WINDOW = False
 
 # Eventos para controle de threads de processamento
 t_processing_stop = Event()
@@ -51,6 +57,9 @@ def processing_loop():
         if frame is None:
             time.sleep(0.1)
             continue
+
+        # Analisa pose e opcionalmente exibe janela
+        position_monitor.analyze_frame(frame, show=SHOW_POSE_WINDOW)
 
         results = processor.process_frame_data(frame)
         if results is None:
@@ -99,6 +108,8 @@ async def lifespan(app: FastAPI):
     t_processing_stop.set()
     t_processing_thread.join(timeout=1)
     camera.stop()
+    if SHOW_POSE_WINDOW:
+        cv2.destroyAllWindows()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from src.processing import VideoProcessor
 from src.notifications import IdentifiedNotifier, TokenRegistry
 from src.monitor.presence_monitor import PresenceMonitor
 from src.firebase_setup import FirebaseSetup
+from src.db import Database
 
 # Configurações e inicialização de câmera e processador
 driver = {
@@ -25,7 +26,12 @@ processor = VideoProcessor(camera)
 token_registry = TokenRegistry()
 fcm_key = os.getenv("FCM_KEY", "")
 notifier = IdentifiedNotifier(fcm_key, cooldown=60)
-presence_monitor = PresenceMonitor(notifier, token_registry)
+db_url = os.getenv("DB_URL")
+if db_url:
+    database = Database(server=Database.SERVER_MYSQL, url=db_url)
+else:
+    database = Database(server=Database.SERVER_MEMORY)
+presence_monitor = PresenceMonitor(notifier, token_registry, database)
 FirebaseSetup().init_firebase()
 
 # Eventos para controle de threads de processamento

--- a/src/monitor/position_monitor.py
+++ b/src/monitor/position_monitor.py
@@ -18,6 +18,7 @@ class PositionMonitor:
         model: YOLO | None = None,
         face_down_margin: float = 20.0,
     ):
+        """Store dependencies and pose parameters."""
         self.notifier = notifier
         self.registry = registry
         self.model = model or YOLO("yolo11n.pt")
@@ -49,5 +50,6 @@ class PositionMonitor:
         self.face_down_sent = False
 
     def _notify_all(self, title: str, message: str) -> None:
+        """Send a notification to all tokens."""
         for token in self.registry.get_all():
             self.notifier.notify(token, title=title, message=message)

--- a/src/monitor/position_monitor.py
+++ b/src/monitor/position_monitor.py
@@ -1,0 +1,49 @@
+from typing import List
+
+from ultralytics import YOLO
+
+from src.notifications.identified_notifier import IdentifiedNotifier
+from src.notifications.token_registry import TokenRegistry
+
+
+class PositionMonitor:
+    """Monitor pose estimation to detect dangerous positions."""
+
+    def __init__(
+        self,
+        notifier: IdentifiedNotifier,
+        registry: TokenRegistry,
+        *,
+        model: YOLO | None = None,
+        face_down_margin: float = 20.0,
+    ):
+        self.notifier = notifier
+        self.registry = registry
+        self.model = model or YOLO("yolo11n.pt")
+        self.face_down_margin = face_down_margin
+        self.face_down_sent = False
+
+    def analyze_frame(self, frame) -> None:
+        """Run pose model on a frame."""
+        results = self.model(frame)
+        self.handle_pose(results)
+
+    def handle_pose(self, results: List) -> None:
+        """Handle pose results and notify if face down."""
+        for result in results or []:
+            keypoints = getattr(result, "keypoints", None)
+            if keypoints is None or not getattr(keypoints, "xy", []):
+                continue
+            nose_y = keypoints.xy[0][1]
+            left_shoulder_y = keypoints.xy[5][1]
+            right_shoulder_y = keypoints.xy[6][1]
+            if nose_y > max(left_shoulder_y, right_shoulder_y) + self.face_down_margin:
+                if not self.face_down_sent:
+                    self._notify_all("Bebê de bruços", "Rosto voltado para baixo")
+                    self.face_down_sent = True
+                return
+        self.face_down_sent = False
+
+    def _notify_all(self, title: str, message: str) -> None:
+        for token in self.registry.get_all():
+            self.notifier.notify(token, title=title, message=message)

--- a/src/monitor/position_monitor.py
+++ b/src/monitor/position_monitor.py
@@ -1,5 +1,6 @@
 from typing import List
 
+import cv2
 from ultralytics import YOLO
 
 from src.notifications.identified_notifier import IdentifiedNotifier
@@ -23,9 +24,12 @@ class PositionMonitor:
         self.face_down_margin = face_down_margin
         self.face_down_sent = False
 
-    def analyze_frame(self, frame) -> None:
-        """Run pose model on a frame."""
+    def analyze_frame(self, frame, show: bool = False) -> None:
+        """Run pose model and optionally display keypoints."""
         results = self.model(frame)
+        if show and results:
+            cv2.imshow("Pose", results[0].plot())
+            cv2.waitKey(1)
         self.handle_pose(results)
 
     def handle_pose(self, results: List) -> None:

--- a/src/monitor/presence_monitor.py
+++ b/src/monitor/presence_monitor.py
@@ -17,6 +17,7 @@ class PresenceMonitor:
         *,
         absence_timeout: int = 30,
     ):
+        """Initialize dependencies and absence tracking state."""
         self.notifier = notifier
         self.registry = registry
         self.db = db
@@ -52,5 +53,6 @@ class PresenceMonitor:
             self.absence_sent = True
 
     def _notify_all(self, title: str, message: str) -> None:
+        """Send a notification to all registered tokens."""
         for t in self.registry.get_all():
             self.notifier.notify(t, title=title, message=message)

--- a/src/monitor/presence_monitor.py
+++ b/src/monitor/presence_monitor.py
@@ -3,14 +3,23 @@ from typing import List
 
 from src.notifications.identified_notifier import IdentifiedNotifier
 from src.notifications.token_registry import TokenRegistry
+from src.db import Database
 
 
 class PresenceMonitor:
     """Monitor camera frames and detections to notify events."""
 
-    def __init__(self, notifier: IdentifiedNotifier, registry: TokenRegistry, *, absence_timeout: int = 30):
+    def __init__(
+        self,
+        notifier: IdentifiedNotifier,
+        registry: TokenRegistry,
+        db: Database,
+        *,
+        absence_timeout: int = 30,
+    ):
         self.notifier = notifier
         self.registry = registry
+        self.db = db
         self.absence_timeout = absence_timeout
         self.last_person_ts = time.time()
         self.absence_sent = False
@@ -39,6 +48,7 @@ class PresenceMonitor:
             self.absence_sent = False
         elif now - self.last_person_ts > self.absence_timeout and not self.absence_sent:
             self._notify_all("Ausência de humano", "Nenhuma pessoa detectada")
+            self.db.save_event({"type": "absence", "confidence": 0.0})
             self.absence_sent = True
 
     def _notify_all(self, title: str, message: str) -> None:

--- a/src/notifications/identified_notifier.py
+++ b/src/notifications/identified_notifier.py
@@ -10,6 +10,7 @@ class IdentifiedNotifier:
     """Send FCM notification when a person is identified."""
 
     def __init__(self, api_key: str, *, threshold: float = 0.9, cooldown: int = 60):
+        """Configure thresholds and underlying notifier."""
         self._threshold = threshold
         self._cooldown = cooldown
         self._notifier = Notifier(api_key)

--- a/src/notifications/notifier.py
+++ b/src/notifications/notifier.py
@@ -7,9 +7,11 @@ class Notifier:
     """Send push notifications via Firebase Admin SDK."""
 
     def __init__(self, api_key: str | None = None):
+        """Store API key if needed for external services."""
         self._api_key = api_key
 
     def send(self, token: str, title: str, message: str):
+        """Send a push notification to a single token."""
         msg = messaging.Message(
             token=token,
             notification=messaging.Notification(title=title, body=message),

--- a/src/notifications/token_registry.py
+++ b/src/notifications/token_registry.py
@@ -2,11 +2,13 @@ class TokenRegistry:
     """Store FCM tokens in a text file."""
 
     def __init__(self, path: str = "tokens.txt"):
+        """Prepare registry at the given file path."""
         self.path = path
         self.tokens = set()
         self._load()
 
     def _load(self) -> None:
+        """Load tokens from disk if available."""
         try:
             with open(self.path, "r") as fh:
                 self.tokens = set(t.strip() for t in fh if t.strip())
@@ -14,15 +16,18 @@ class TokenRegistry:
             self.tokens = set()
 
     def _save(self) -> None:
+        """Persist tokens to disk."""
         with open(self.path, "w") as fh:
             for t in sorted(self.tokens):
                 fh.write(t + "\n")
 
     def add(self, token: str) -> None:
+        """Add a token if new and save immediately."""
         if not token or token in self.tokens:
             return
         self.tokens.add(token)
         self._save()
 
     def get_all(self):
+        """Return all stored tokens."""
         return list(self.tokens)

--- a/src/processing/video_processor.py
+++ b/src/processing/video_processor.py
@@ -3,12 +3,14 @@ import cv2
 
 class VideoProcessor:
     def __init__(self, camera_handler):
+        """Wrap a camera handler and load a YOLO model."""
         self.camera = camera_handler
 
         # Carrega modelo leve YOLOv8n (pré-treinado para detecção de pessoas)
-        self.model = YOLO("yolo11n.pt")  
+        self.model = YOLO("yolo11n.pt")
 
     def process_frame(self):
+        """Return frame with person detections drawn."""
         frame = self.camera.get_frame()
         if frame is None:
             return None

--- a/tests/test_position_monitor.py
+++ b/tests/test_position_monitor.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest.mock import MagicMock
+
+from src.monitor.position_monitor import PositionMonitor
+
+
+class TestPositionMonitor(unittest.TestCase):
+    def test_face_down_detection(self):
+        notifier = MagicMock()
+        registry = MagicMock()
+        registry.get_all.return_value = ["tok"]
+        monitor = PositionMonitor(notifier, registry, model=MagicMock(), face_down_margin=0)
+
+        face_down = MagicMock()
+        kps = MagicMock()
+        # nose_y > shoulders_y triggers notification
+        kps.xy = [
+            (0, 50),  # nose
+            (0, 0),   # placeholders for remaining keypoints
+            (0, 0),
+            (0, 0),
+            (0, 0),
+            (0, 20),  # left_shoulder
+            (0, 20),  # right_shoulder
+        ]
+        face_down.keypoints = kps
+
+        safe = MagicMock()
+        kps_safe = MagicMock()
+        kps_safe.xy = [
+            (0, 10),
+            (0, 0),
+            (0, 0),
+            (0, 0),
+            (0, 0),
+            (0, 20),
+            (0, 20),
+        ]
+        safe.keypoints = kps_safe
+
+        monitor.handle_pose([face_down])
+        notifier.notify.assert_called_once()
+
+        monitor.handle_pose([safe])
+        monitor.handle_pose([face_down])
+        self.assertEqual(notifier.notify.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_presence_monitor.py
+++ b/tests/test_presence_monitor.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from src.monitor.presence_monitor import PresenceMonitor
+from src.db import Database
 
 
 class TestPresenceMonitor(unittest.TestCase):
@@ -11,9 +12,11 @@ class TestPresenceMonitor(unittest.TestCase):
         registry = MagicMock()
         registry.get_all.return_value = ['tok']
         mock_time.time.side_effect = [0, 31, 31, 32]
+        db = Database(server=Database.SERVER_MEMORY)
 
-        monitor = PresenceMonitor(notifier, registry, absence_timeout=30)
+        monitor = PresenceMonitor(notifier, registry, db, absence_timeout=30)
         monitor.handle_detections([])
+        self.assertTrue(any(e['type'] == 'absence' for e in db.get_recent_events()))
         monitor.check_camera('frame')
         monitor.handle_detections([])
         notifier.notify.assert_called_once()


### PR DESCRIPTION
## Summary
- log absence events via Database in PresenceMonitor
- wire Database into main startup
- test absence event persistence

## Testing
- `python -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_689689a81490832abb9932bfb95898cf