### PR TITLE
Share memory events across Database instances

### DIFF
--- a/src/db/database.py
+++ b/src/db/database.py
@@ -9,6 +9,9 @@ from sqlalchemy.orm import sessionmaker
 
 Base = declarative_base()
 
+# Lista global de eventos quando o backend está em memória
+memory_events: List[Dict[str, str]] = []
+
 
 class Event(Base):
     """Tabela de eventos para o banco SQL."""
@@ -30,7 +33,7 @@ class Database:
         """Initialize the database backend."""
         self.server = server
         if server == self.SERVER_MEMORY:
-            self._events: List[Dict[str, str]] = []
+            self._events = memory_events
         elif server == self.SERVER_MYSQL:
             if url is None:
                 raise ValueError("URL required for MySQL server")

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -10,6 +10,7 @@ sys.modules.setdefault('ultralytics', MagicMock())
 
 from src.camera.handler import CameraHandler
 from src.processing.video_processor import VideoProcessor
+from src.db.database import memory_events
 
 class TestCameraHandler(unittest.TestCase):
     @patch('src.camera.handler.cv2.VideoCapture')
@@ -41,6 +42,9 @@ class TestVideoProcessor(unittest.TestCase):
         self.assertEqual(proc.get_processed_frame(), 'frame')
 
 class TestDatabase(unittest.TestCase):
+    def setUp(self):
+        memory_events.clear()
+
     def test_memory_mode(self):
         from src.db.database import Database
         db = Database(server=Database.SERVER_MEMORY)

--- a/tests/test_database_memory.py
+++ b/tests/test_database_memory.py
@@ -1,0 +1,20 @@
+import unittest
+
+from src.db.database import Database, memory_events
+
+
+class TestDatabaseMemoryGlobal(unittest.TestCase):
+    def setUp(self):
+        memory_events.clear()
+
+    def test_shared_events_across_instances(self):
+        db1 = Database(server=Database.SERVER_MEMORY)
+        db2 = Database(server=Database.SERVER_MEMORY)
+        db1.save_event({'type': 'share', 'confidence': 0.1})
+        self.assertEqual(len(db2.get_recent_events()), 1)
+        db2.save_event({'type': 'other', 'confidence': 0.2})
+        self.assertEqual(len(db1.get_recent_events()), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_presence_monitor.py
+++ b/tests/test_presence_monitor.py
@@ -3,9 +3,13 @@ from unittest.mock import MagicMock, patch
 
 from src.monitor.presence_monitor import PresenceMonitor
 from src.db import Database
+from src.db.database import memory_events
 
 
 class TestPresenceMonitor(unittest.TestCase):
+    def setUp(self):
+        memory_events.clear()
+
     @patch('src.monitor.presence_monitor.time')
     def test_absence_and_camera_notifications(self, mock_time):
         notifier = MagicMock()


### PR DESCRIPTION
## Summary
- use module-level `memory_events` list so memory databases share events
- reset memory events in tests and add coverage for shared behavior

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_689bc3640e50832ab8b8caacd2601268