### PR TITLE
Improve PTZ compatibility with constrained cameras

### DIFF
--- a/src/camera/handler.py
+++ b/src/camera/handler.py
@@ -1,6 +1,10 @@
 import socket
 import os
 import logging
+import re
+from datetime import timedelta
+from typing import Any
+
 # Suprime logs do OpenCV/FFmpeg
 os.environ["OPENCV_LOG_LEVEL"] = "SILENT"
 
@@ -9,6 +13,63 @@ from onvif import ONVIFCamera
 from threading import Thread, Event, Lock
 from collections import deque
 import time
+
+_DURATION_RE = re.compile(
+    r"^P(?:(?P<days>\d+)D)?"
+    r"(?:T(?:(?P<hours>\d+)H)?(?:(?P<minutes>\d+)M)?(?:(?P<seconds>\d+(?:\.\d+)?)S)?)?$"
+)
+
+
+def _as_iterable(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
+
+
+def _get_attr_or_key(obj: Any, name: str) -> Any:
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return float(value)
+        except Exception:
+            return None
+    try:
+        return float(str(value))
+    except Exception:
+        return None
+
+
+def _coerce_timeout_seconds(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return float(value)
+        except Exception:
+            return None
+    if isinstance(value, timedelta):
+        return max(value.total_seconds(), 0.0)
+    if isinstance(value, str):
+        match = _DURATION_RE.fullmatch(value.strip())
+        if not match:
+            return None
+        days = float(match.group("days") or 0)
+        hours = float(match.group("hours") or 0)
+        minutes = float(match.group("minutes") or 0)
+        seconds = float(match.group("seconds") or 0)
+        return max(days * 86400 + hours * 3600 + minutes * 60 + seconds, 0.0)
+    return None
 
 # Timeout global para conexões socket ONVIF (em segundos)
 socket.setdefaulttimeout(2)
@@ -87,6 +148,16 @@ class CameraHandler:
         self._reconnecting: bool = False
         self._reconnect_thread: Thread | None = None
         self._reconnect_delay: float = 5.0
+
+        # Configurações de PTZ
+        self._ptz_service = None
+        self._ptz_profile_token: str | None = None
+        self._ptz_configuration_token: str | None = None
+        self._ptz_timeout_min: float = 1.0
+        self._ptz_timeout_max: float = 10.0
+        self._ptz_timeout: float = 1.0
+        self._ptz_pan_limit: float | None = None
+        self._ptz_tilt_limit: float | None = None
 
     def _sleep_interruptible(self, seconds: float, step: float = 0.1) -> None:
         """Sleep in small steps so stop() can interrupt long waits."""
@@ -223,7 +294,19 @@ class CameraHandler:
             if self.source == "onvif":
                 self._camera = ONVIFCamera(self.host, self.port, self.user, self.passwd)
                 media = self._camera.create_media_service()
-                profile = media.GetProfiles()[0]
+                self._ptz_service = None
+                try:
+                    self._ptz_service = self._camera.create_ptz_service()
+                except Exception as exc:
+                    logging.warning("Falha ao criar serviço PTZ: %s", exc)
+                    self._ptz_service = None
+
+                profile = self._select_media_profile(media)
+                if profile is None:
+                    raise RuntimeError("Nenhum profile disponível no serviço de mídia")
+
+                self._setup_ptz_capabilities(profile)
+
                 uri = media.GetStreamUri({
                     "StreamSetup": {"Stream": "RTP-Unicast", "Transport": {"Protocol": "RTSP"}},
                     "ProfileToken": profile.token,
@@ -294,6 +377,154 @@ class CameraHandler:
         self._thread = Thread(target=self._capture_loop, daemon=True)
         self._thread.start()
 
+    def _select_media_profile(self, media_service) -> Any:
+        """Seleciona um profile que possua configuração PTZ quando disponível."""
+        try:
+            profiles = media_service.GetProfiles()
+        except Exception as exc:
+            logging.warning("Falha ao obter profiles ONVIF: %s", exc)
+            return None
+        if not profiles:
+            return None
+        for profile in profiles:
+            if getattr(profile, "PTZConfiguration", None):
+                return profile
+        return profiles[0]
+
+    def _setup_ptz_capabilities(self, profile: Any) -> None:
+        """Guarda tokens, limites de velocidade e timeout compatíveis com a câmera."""
+        self._ptz_pan_limit = None
+        self._ptz_tilt_limit = None
+        self._ptz_timeout_min = 1.0
+        self._ptz_timeout_max = 10.0
+        self._ptz_timeout = 1.0
+        self._ptz_profile_token = getattr(profile, "token", None)
+        ptz_config = getattr(profile, "PTZConfiguration", None)
+        self._ptz_configuration_token = getattr(ptz_config, "token", None)
+
+        timeout = _coerce_timeout_seconds(
+            getattr(ptz_config, "DefaultPTZTimeout", None)
+            if ptz_config
+            else None
+        )
+        if timeout is not None:
+            self._ptz_timeout = timeout
+
+        # Obtém limites detalhados, se o serviço PTZ estiver disponível
+        if not self._ptz_service or not self._ptz_configuration_token:
+            # Garante limites padrão seguros
+            if self._ptz_pan_limit is None:
+                self._ptz_pan_limit = 1.0
+            if self._ptz_tilt_limit is None:
+                self._ptz_tilt_limit = 1.0
+            self._ptz_timeout = self._clamp_timeout(self._ptz_timeout)
+            return
+
+        try:
+            options = self._ptz_service.GetConfigurationOptions(
+                {"ConfigurationToken": self._ptz_configuration_token}
+            )
+        except Exception as exc:
+            logging.warning("Falha ao obter opções PTZ: %s", exc)
+            if self._ptz_pan_limit is None:
+                self._ptz_pan_limit = 1.0
+            if self._ptz_tilt_limit is None:
+                self._ptz_tilt_limit = 1.0
+            self._ptz_timeout = self._clamp_timeout(self._ptz_timeout)
+            return
+
+        spaces = _get_attr_or_key(options, "Spaces")
+        pan_limit = self._ptz_pan_limit
+        tilt_limit = self._ptz_tilt_limit
+        for entry in (
+            "ContinuousPanTiltVelocitySpace",
+            "PanTiltVelocitySpace",
+            "VelocitySpace",
+        ):
+            for space in _as_iterable(_get_attr_or_key(spaces, entry)):
+                x_range = _get_attr_or_key(space, "XRange")
+                y_range = _get_attr_or_key(space, "YRange")
+                if x_range is None and y_range is None:
+                    range_info = _get_attr_or_key(space, "Range")
+                    x_range = _get_attr_or_key(range_info, "XRange")
+                    y_range = _get_attr_or_key(range_info, "YRange")
+
+                x_min = _coerce_float(_get_attr_or_key(x_range, "Min"))
+                x_max = _coerce_float(_get_attr_or_key(x_range, "Max"))
+                y_min = _coerce_float(_get_attr_or_key(y_range, "Min"))
+                y_max = _coerce_float(_get_attr_or_key(y_range, "Max"))
+
+                if x_min is not None and x_max is not None:
+                    limit = max(abs(x_min), abs(x_max))
+                    if limit > 0:
+                        pan_limit = limit if pan_limit is None else min(pan_limit, limit)
+                if y_min is not None and y_max is not None:
+                    limit = max(abs(y_min), abs(y_max))
+                    if limit > 0:
+                        tilt_limit = limit if tilt_limit is None else min(tilt_limit, limit)
+
+        timeout_range = None
+        for key in ("TimeoutRange", "PTZTimeout", "Timeout"):
+            timeout_range = _get_attr_or_key(options, key)
+            if timeout_range:
+                break
+
+        min_timeout = _coerce_timeout_seconds(_get_attr_or_key(timeout_range, "Min"))
+        max_timeout = _coerce_timeout_seconds(_get_attr_or_key(timeout_range, "Max"))
+
+        if min_timeout is not None and max_timeout is not None and min_timeout <= max_timeout:
+            self._ptz_timeout_min = max(0.1, min_timeout)
+            self._ptz_timeout_max = max(min_timeout, max_timeout)
+        self._ptz_timeout = self._clamp_timeout(self._ptz_timeout)
+
+        self._ptz_pan_limit = pan_limit if pan_limit is not None else 1.0
+        self._ptz_tilt_limit = tilt_limit if tilt_limit is not None else 1.0
+
+    def _clamp_timeout(self, value: float | None) -> float:
+        base = self._ptz_timeout_min if self._ptz_timeout_min else 0.5
+        max_allowed = self._ptz_timeout_max if self._ptz_timeout_max else max(base, 1.0)
+        if value is None:
+            value = base
+        try:
+            value = float(value)
+        except Exception:
+            value = base
+        if value <= 0:
+            value = base
+        value = max(base, value)
+        value = min(max_allowed, value)
+        return value
+
+    def _refresh_ptz_state(self) -> None:
+        if not self.ptz_enabled or self._camera is None:
+            return
+        try:
+            media = self._camera.create_media_service()
+        except Exception as exc:
+            logging.warning("Falha ao atualizar perfil PTZ: %s", exc)
+            return
+
+        if self._ptz_service is None:
+            try:
+                self._ptz_service = self._camera.create_ptz_service()
+            except Exception as exc:
+                logging.warning("Falha ao recriar serviço PTZ: %s", exc)
+                self._ptz_service = None
+                return
+
+        profile = self._select_media_profile(media)
+        if profile is None:
+            return
+        self._setup_ptz_capabilities(profile)
+
+    def _format_timeout(self) -> str:
+        seconds = self._clamp_timeout(self._ptz_timeout)
+        self._ptz_timeout = seconds
+        if abs(seconds - round(seconds)) < 1e-3:
+            return f"PT{int(round(seconds))}S"
+        numeric = f"{seconds:.2f}".rstrip("0").rstrip(".")
+        return f"PT{numeric}S"
+
     def _schedule_reconnect(self) -> None:
         """Agenda tentativas de reconexão a cada 5s até sucesso."""
         if self._reconnecting or self._stop.is_set():
@@ -320,41 +551,52 @@ class CameraHandler:
         """Retorna True se a thread e a captura estiverem ativas."""
         return bool(self._cap and self._cap.isOpened() and self._thread and self._thread.is_alive())
 
-    def control_ptz(self, err_x: float, err_y: float, kp: float = 0.6):
-        """Controla PTZ (ativo somente em ONVIF)."""
+    def control_ptz(self, err_x: float, err_y: float, kp: float = 0.6) -> None:
+        """Controla PTZ respeitando limites do dispositivo informado."""
         if not self.ptz_enabled or self._camera is None:
             return
-        try:
-            ptz = self._camera.create_ptz_service()
-            media = self._camera.create_media_service()
-            profile = media.GetProfiles()[0]
-            token = profile.token
-        
-            # Aplica ganho proporcional
-            vx = kp * err_x
-            vy = kp * err_y
-        
-            # Limita velocidades entre -1.0 e 1.0
-            vx = max(min(vx, 1.0), -1.0)
-            vy = max(min(vy, 1.0), -1.0)
-        
-            # Monta comando de movimento
-            ptz.ContinuousMove({
-                "ProfileToken": token,
-                "Velocity": {
-                    "PanTilt": {
-                        "x": -vx,
-                        "y": -vy  # Inverte se necessário (ajuste depende da câmera)
-                    }
+
+        # Garante que tokens/configurações estejam carregados
+        if not self._ptz_profile_token or not self._ptz_service:
+            self._refresh_ptz_state()
+
+        if not self._ptz_service or not self._ptz_profile_token:
+            return
+
+        vx = kp * err_x
+        vy = kp * err_y
+
+        pan_limit = self._ptz_pan_limit if self._ptz_pan_limit is not None else 1.0
+        tilt_limit = self._ptz_tilt_limit if self._ptz_tilt_limit is not None else 1.0
+
+        vx = max(min(vx, pan_limit), -pan_limit)
+        vy = max(min(vy, tilt_limit), -tilt_limit)
+
+        if abs(vx) < 1e-3 and abs(vy) < 1e-3:
+            return
+
+        payload = {
+            "ProfileToken": self._ptz_profile_token,
+            "Velocity": {
+                "PanTilt": {
+                    "x": -vx,
+                    "y": -vy,
                 }
-            })
-        
-            # Aguarda movimento curto, depois para
-            time.sleep(0.2)
-            ptz.Stop({"ProfileToken": token})
-        
-        except Exception as e:
-            logging.warning("Falha no controle PTZ: %s", e)
+            },
+            "Timeout": self._format_timeout(),
+        }
+
+        try:
+            self._ptz_service.ContinuousMove(payload)
+        except Exception as exc:
+            logging.warning("Falha ao enviar comando PTZ: %s", exc)
+            return
+
+        try:
+            time.sleep(min(0.2, self._ptz_timeout))
+            self._ptz_service.Stop({"ProfileToken": self._ptz_profile_token})
+        except Exception as exc:
+            logging.debug("Falha ao finalizar movimento PTZ: %s", exc)
 
 
     def stop(self) -> None:
@@ -373,3 +615,6 @@ class CameraHandler:
                 self._camera.devicemgmt.Stop()
             except:
                 pass
+        self._ptz_service = None
+        self._ptz_profile_token = None
+        self._ptz_configuration_token = None

--- a/tests/test_camera_ptz.py
+++ b/tests/test_camera_ptz.py
@@ -1,0 +1,100 @@
+import sys
+import types
+from unittest import TestCase
+from unittest.mock import patch
+
+
+if "cv2" not in sys.modules:
+    dummy_cv2 = types.SimpleNamespace(
+        VideoCapture=lambda *args, **kwargs: None,
+        CAP_FFMPEG=0,
+        CAP_PROP_FRAME_WIDTH=3,
+        CAP_PROP_FRAME_HEIGHT=4,
+        CAP_PROP_BUFFERSIZE=5,
+        CAP_PROP_OPEN_TIMEOUT_MSEC=6,
+        CAP_PROP_READ_TIMEOUT_MSEC=7,
+    )
+    sys.modules["cv2"] = dummy_cv2
+
+from src.camera.handler import CameraHandler
+
+
+class _DummyPTZService:
+    def __init__(self):
+        self.moves: list[dict] = []
+        self.stop_payloads: list[dict] = []
+
+    def ContinuousMove(self, payload):  # noqa: N802 - mantém interface ONVIF
+        self.moves.append(payload)
+
+    def Stop(self, payload):  # noqa: N802 - mantém interface ONVIF
+        self.stop_payloads.append(payload)
+
+
+class _DummyCamera:
+    def __init__(self, ptz_service=None, media_profiles=None):
+        self._ptz_service = ptz_service
+        self._media_profiles = media_profiles or []
+
+    def create_ptz_service(self):
+        if isinstance(self._ptz_service, Exception):
+            raise self._ptz_service
+        return self._ptz_service
+
+    def create_media_service(self):
+        service = types.SimpleNamespace()
+        service.GetProfiles = lambda: self._media_profiles
+        return service
+
+
+class CameraHandlerPTZTest(TestCase):
+    def setUp(self):
+        self.handler = CameraHandler("host", 80, "user", "pass")
+        self.handler.ptz_enabled = True
+
+    @patch("src.camera.handler.time.sleep", autospec=True)
+    def test_control_ptz_limits_velocity_and_timeout(self, mock_sleep):
+        ptz_service = _DummyPTZService()
+        profile = types.SimpleNamespace(
+            token="Profile000",
+            PTZConfiguration=types.SimpleNamespace(
+                token="PTZ000",
+                DefaultPTZTimeout="PT10S",
+            ),
+        )
+        self.handler._camera = _DummyCamera(ptz_service, [profile])
+        self.handler._ptz_service = ptz_service
+        self.handler._ptz_profile_token = "Profile000"
+        self.handler._ptz_configuration_token = "PTZ000"
+        self.handler._ptz_pan_limit = 1.0
+        self.handler._ptz_tilt_limit = 1.0
+        self.handler._ptz_timeout = 1.0
+
+        self.handler.control_ptz(err_x=5.0, err_y=-5.0)
+
+        self.assertEqual(len(ptz_service.moves), 1)
+        move = ptz_service.moves[0]
+        self.assertEqual(move["ProfileToken"], "Profile000")
+        self.assertEqual(move["Timeout"], "PT1S")
+        self.assertAlmostEqual(move["Velocity"]["PanTilt"]["x"], -1.0)
+        self.assertAlmostEqual(move["Velocity"]["PanTilt"]["y"], 1.0)
+        self.assertTrue(ptz_service.stop_payloads)
+        self.assertEqual(
+            ptz_service.stop_payloads[-1]["ProfileToken"], "Profile000"
+        )
+        mock_sleep.assert_called()
+
+    def test_control_ptz_without_tokens_does_nothing(self):
+        ptz_service = _DummyPTZService()
+        failing_camera = _DummyCamera(ptz_service)
+        failing_camera.create_media_service = lambda: (_ for _ in ()).throw(  # type: ignore
+            RuntimeError("no media")
+        )
+        self.handler._camera = failing_camera
+        self.handler._ptz_service = ptz_service
+        self.handler._ptz_profile_token = None
+
+        self.handler.control_ptz(err_x=1.0, err_y=1.0)
+
+        self.assertEqual(ptz_service.moves, [])
+        self.assertEqual(ptz_service.stop_payloads, [])


### PR DESCRIPTION
## Summary
- adjust PTZ initialization to pick the correct media profile and cache configuration limits
- clamp pan/tilt velocities and command timeouts to the ranges supported by the ONVIF camera
- add unit tests covering the new PTZ control logic with a stubbed cv2 dependency

## Testing
- python -m unittest tests.test_camera_ptz

------
https://chatgpt.com/codex/tasks/task_e_68df073d570c832a8e04962db6e2bada